### PR TITLE
Use variables instead of modifiers for hyper key.

### DIFF
--- a/mac/caps_lock.json
+++ b/mac/caps_lock.json
@@ -19,16 +19,18 @@
               ]
             }
           },
-          "to": [
-            {
-              "key_code": "right_shift",
-              "modifiers": [
-                "right_command",
-                "right_control",
-                "right_option"
-              ]
+          "to": [{
+            "set_variable": {
+              "name": "caps_lock pressed",
+              "value": 1
             }
-          ],
+          }],
+          "to_after_key_up": [{
+            "set_variable": {
+              "name": "caps_lock pressed",
+              "value": 0
+            }
+          }],
           "to_if_alone": [
             {
               "key_code": "escape"
@@ -43,170 +45,78 @@
         {
           "type": "basic",
           "from": {
-            "key_code": "h",
-            "modifiers": {
-              "mandatory": [
-                "left_command",
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
-              ]
-            }
-          },
-          "to": [
-            {
-              "key_code": "left_arrow",
-              "modifiers": [
-                "left_shift"
-              ]
-            }
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "h",
-            "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
-              ]
-            }
-          },
-          "to": [
-            {
-              "key_code": "left_arrow"
-            }
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
             "key_code": "j",
             "modifiers": {
-              "mandatory": [
-                "left_command",
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
-          "to": [
-            {
-              "key_code": "down_arrow",
-              "modifiers": [
-                "left_shift"
-              ]
-            }
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "j",
-            "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
-              ]
-            }
-          },
-          "to": [
-            {
-              "key_code": "down_arrow"
-            }
-          ]
-        },
+          "to": [{
+            "key_code": "down_arrow"
+          }],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
+        }, 
         {
           "type": "basic",
           "from": {
             "key_code": "k",
             "modifiers": {
-              "mandatory": [
-                "left_command",
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
-          "to": [
-            {
-              "key_code": "up_arrow",
-              "modifiers": [
-                "left_shift"
-              ]
-            }
-          ]
+          "to": [{
+            "key_code": "up_arrow"
+          }],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
-            "key_code": "k",
+            "key_code": "h",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
-          "to": [
-            {
-              "key_code": "up_arrow"
-            }
-          ]
+          "to": [{
+            "key_code": "left_arrow"
+          }],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "l",
             "modifiers": {
-              "mandatory": [
-                "left_command",
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
-          "to": [
-            {
-              "key_code": "right_arrow",
-              "modifiers": [
-                "left_shift"
-              ]
-            }
-          ]
-        },
-        {
-          "type": "basic",
-          "from": {
-            "key_code": "l",
-            "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
-              ]
-            }
-          },
-          "to": [
-            {
-              "key_code": "right_arrow"
-            }
-          ]
+          "to": [{
+            "key_code": "right_arrow"
+          }],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
@@ -214,11 +124,7 @@
             "key_code": "u",
             "modifiers": {
               "mandatory": [
-                "left_command",
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+                "left_command"
               ]
             }
           },
@@ -229,18 +135,20 @@
                 "left_shift"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "u",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -248,7 +156,12 @@
             {
               "key_code": "page_up"
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
@@ -256,11 +169,7 @@
             "key_code": "i",
             "modifiers": {
               "mandatory": [
-                "left_command",
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+                "left_command"
               ]
             }
           },
@@ -271,18 +180,20 @@
                 "left_shift"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "i",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -290,7 +201,12 @@
             {
               "key_code": "home"
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
@@ -298,11 +214,7 @@
             "key_code": "o",
             "modifiers": {
               "mandatory": [
-                "left_command",
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+                "left_command"
               ]
             }
           },
@@ -313,18 +225,20 @@
                 "left_shift"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "o",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -332,7 +246,12 @@
             {
               "key_code": "end"
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
@@ -340,11 +259,7 @@
             "key_code": "p",
             "modifiers": {
               "mandatory": [
-                "left_command",
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+                "left_command"
               ]
             }
           },
@@ -355,18 +270,20 @@
                 "left_shift"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "p",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -374,7 +291,12 @@
             {
               "key_code": "page_down"
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         }
       ]
     },
@@ -387,11 +309,7 @@
             "key_code": "n",
             "modifiers": {
               "mandatory": [
-                "left_command",
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+                "left_command"
               ]
             }
           },
@@ -402,18 +320,20 @@
                 "left_command"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "n",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -424,7 +344,12 @@
                 "left_option"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
@@ -432,11 +357,7 @@
             "key_code": "m",
             "modifiers": {
               "mandatory": [
-                "left_command",
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+                "left_command"
               ]
             }
           },
@@ -447,18 +368,20 @@
                 "left_command"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "m",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -466,18 +389,20 @@
             {
               "key_code": "delete_or_backspace"
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "comma",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -485,18 +410,20 @@
             {
               "key_code": "delete_forward"
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "period",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -507,7 +434,12 @@
                 "left_option"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         }
       ]
     },
@@ -520,11 +452,7 @@
             "key_code": "tab",
             "modifiers": {
               "mandatory": [
-                "left_command",
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+                "left_command"
               ]
             }
           },
@@ -536,18 +464,20 @@
                 "left_shift"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "tab",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -558,18 +488,20 @@
                 "left_command"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "q",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -580,18 +512,20 @@
                 "left_command"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "w",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -602,7 +536,12 @@
                 "left_command"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
@@ -610,11 +549,7 @@
             "key_code": "e",
             "modifiers": {
               "mandatory": [
-                "left_command",
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+                "left_command"
               ]
             }
           },
@@ -622,18 +557,20 @@
             {
               "shell_command": "open -a 'finder'"
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "e",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -641,7 +578,12 @@
             {
               "shell_command": "open -a 'Safari'"
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
@@ -649,11 +591,7 @@
             "key_code": "a",
             "modifiers": {
               "mandatory": [
-                "left_command",
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+                "left_command"
               ]
             }
           },
@@ -664,7 +602,12 @@
                 "left_control"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
@@ -672,11 +615,7 @@
             "key_code": "s",
             "modifiers": {
               "mandatory": [
-                "left_command",
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+                "left_command"
               ]
             }
           },
@@ -688,18 +627,20 @@
                 "left_shift"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "s",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -710,7 +651,12 @@
                 "left_control"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
@@ -718,11 +664,7 @@
             "key_code": "d",
             "modifiers": {
               "mandatory": [
-                "left_command",
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+                "left_command"
               ]
             }
           },
@@ -730,7 +672,12 @@
             {
               "key_code": "f11"
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         }
       ]
     },
@@ -742,11 +689,8 @@
           "from": {
             "key_code": "z",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -757,18 +701,20 @@
                 "left_control"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "x",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -779,18 +725,20 @@
                 "left_control"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "c",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -801,18 +749,20 @@
                 "left_control"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "v",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -823,18 +773,20 @@
                 "left_control"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "b",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -845,18 +797,20 @@
                 "left_control"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "d",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -867,7 +821,12 @@
                 "left_control"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         }
       ]
     },
@@ -880,11 +839,7 @@
             "key_code": "r",
             "modifiers": {
               "mandatory": [
-                "left_command",
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+                "left_command"
               ]
             }
           },
@@ -892,18 +847,20 @@
             {
               "shell_command": "open -a 'Preview'"
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "r",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -911,7 +868,12 @@
             {
               "shell_command": "open -a 'iTerm'"
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
@@ -919,11 +881,7 @@
             "key_code": "t",
             "modifiers": {
               "mandatory": [
-                "left_command",
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+                "left_command"
               ]
             }
           },
@@ -931,18 +889,20 @@
             {
               "shell_command": "open -a 'Typora'"
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "t",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -950,18 +910,20 @@
             {
               "shell_command": "open -a 'Visual Studio Code'"
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "y",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -969,7 +931,12 @@
             {
               "shell_command": "open -a 'Siri'"
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
@@ -977,11 +944,7 @@
             "key_code": "f",
             "modifiers": {
               "mandatory": [
-                "left_command",
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+                "left_command"
               ]
             }
           },
@@ -989,18 +952,20 @@
             {
               "shell_command": "open -a 'Dictionary'"
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "f",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1008,26 +973,33 @@
             {
               "shell_command": "open -a 'Dash'"
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "g",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
           "to": [
             {
-              "shell_command": "open -a 'IntelliJ IDEA'"
+              "shell_command": "open -a 'IntelliJ IDEA CE'"
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
@@ -1035,11 +1007,7 @@
             "key_code": "g",
             "modifiers": {
               "mandatory": [
-                "left_command",
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+                "left_command"
               ]
             }
           },
@@ -1047,7 +1015,12 @@
             {
               "shell_command": "open -a 'Google Chrome'"
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         }
       ]
     },
@@ -1059,11 +1032,8 @@
           "from": {
             "key_code": "f1",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1071,18 +1041,20 @@
             {
               "key_code": "display_brightness_decrement"
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "f2",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1090,18 +1062,20 @@
             {
               "key_code": "display_brightness_increment"
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "f3",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1112,18 +1086,20 @@
                 "left_control"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "f4",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1131,18 +1107,20 @@
             {
               "shell_command": "open -a 'Launchpad'"
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "f5",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1150,18 +1128,20 @@
             {
               "key_code": "illumination_decrement"
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "f6",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1169,18 +1149,20 @@
             {
               "key_code": "illumination_increment"
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "f7",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1188,18 +1170,20 @@
             {
               "key_code": "rewind"
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "f8",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1207,18 +1191,20 @@
             {
               "key_code": "play_or_pause"
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "f9",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1226,18 +1212,20 @@
             {
               "key_code": "fastforward"
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "f10",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1245,18 +1233,20 @@
             {
               "key_code": "mute"
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "f11",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1264,18 +1254,20 @@
             {
               "key_code": "volume_decrement"
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "f12",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1283,18 +1275,20 @@
             {
               "key_code": "volume_increment"
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "f13",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1302,18 +1296,20 @@
             {
               "key_code": "rewind"
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "f14",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1321,18 +1317,20 @@
             {
               "key_code": "fastforward"
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "f15",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1340,18 +1338,20 @@
             {
               "key_code": "mute"
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "help",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1363,18 +1363,20 @@
                 "left_option"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "delete_forward",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1386,18 +1388,20 @@
                 "left_option"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "home",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1409,18 +1413,20 @@
                 "left_option"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "end",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1432,18 +1438,20 @@
                 "left_option"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "page_down",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1451,18 +1459,20 @@
             {
               "key_code": "volume_decrement"
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "page_up",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1470,7 +1480,12 @@
             {
               "key_code": "volume_increment"
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         }
       ]
     },
@@ -1482,11 +1497,8 @@
           "from": {
             "key_code": "1",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1497,18 +1509,20 @@
                 "left_shift"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "2",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1519,18 +1533,20 @@
                 "left_shift"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "3",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1541,18 +1557,20 @@
                 "left_shift"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "4",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1563,18 +1581,20 @@
                 "left_shift"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "5",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1585,18 +1605,20 @@
                 "left_shift"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "6",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1607,18 +1629,20 @@
                 "left_shift"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "7",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1629,18 +1653,20 @@
                 "left_shift"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "8",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1651,18 +1677,20 @@
                 "left_shift"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "9",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1673,18 +1701,20 @@
                 "left_shift"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "0",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1695,18 +1725,20 @@
                 "left_shift"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "hyphen",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1717,18 +1749,20 @@
                 "left_shift"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "equal_sign",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1739,18 +1773,20 @@
                 "left_shift"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "open_bracket",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1761,18 +1797,20 @@
                 "left_shift"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "close_bracket",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1783,18 +1821,20 @@
                 "left_shift"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "backslash",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1805,18 +1845,20 @@
                 "left_shift"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "semicolon",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1827,18 +1869,20 @@
                 "left_shift"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "quote",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1849,7 +1893,12 @@
                 "left_shift"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         }
       ]
     },
@@ -1862,11 +1911,7 @@
             "key_code": "grave_accent_and_tilde",
             "modifiers": {
               "mandatory": [
-                "left_command",
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+                "left_command"
               ]
             }
           },
@@ -1878,18 +1923,20 @@
                 "left_command"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "grave_accent_and_tilde",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1902,18 +1949,20 @@
                 "left_command"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "delete_or_backspace",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1924,18 +1973,20 @@
                 "left_command"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "return_or_enter",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1943,18 +1994,20 @@
             {
               "key_code": "equal_sign"
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "slash",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1965,18 +2018,20 @@
                 "left_command"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         },
         {
           "type": "basic",
           "from": {
             "key_code": "spacebar",
             "modifiers": {
-              "mandatory": [
-                "right_command",
-                "right_control",
-                "right_shift",
-                "right_option"
+              "optional": [
+                "any"
               ]
             }
           },
@@ -1987,7 +2042,12 @@
                 "left_control"
               ]
             }
-          ]
+          ],
+          "conditions": [{
+            "type": "variable_if",
+            "name": "caps_lock pressed",
+            "value": 1
+          }]
         }
       ]
     }

--- a/mac/setup
+++ b/mac/setup
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 mkdir -p "${HOME}/.config/karabiner/assets/complex_modifications/"
-cp ./capslock.json "${HOME}/.config/karabiner/assets/complex_modifications/capslock.json"
-echo "${HOME}/.config/karabiner/assets/complex_modifications/capslock.json" Done
+cp ./caps_lock.json "${HOME}/.config/karabiner/assets/complex_modifications/caps_lock.json"
+echo "${HOME}/.config/karabiner/assets/complex_modifications/caps_lock.json" Done


### PR DESCRIPTION
Use `set_variable` to control hyper state rather than mapping to `right_command`, `right_control`, `right_option`.

Some applications, IntelliJ for instance, gets confused if one tries to use modifiers when navigating with `hjkl`. E.g. selecting words with `✱⇧⌥h` doesn't work.