### PR TITLE
typo: ✻ t = vscode

### DIFF
--- a/mac/capslock.json
+++ b/mac/capslock.json
@@ -4943,7 +4943,7 @@
           ]
         },
         {
-          "description": "t = iTerm2",
+          "description": "t = vscode",
           "type": "basic",
           "from": {
             "key_code": "t",


### PR DESCRIPTION

I read the CapsLock Docs all afternoon, 

I dont know why it is so fantanstic to me, I dont feel tired.