### PR TITLE
Navigation category part error fix

### DIFF
--- a/mac_v3/capslock.json
+++ b/mac_v3/capslock.json
@@ -2175,7 +2175,7 @@
           "to": [
             {
               "mouse_key": {
-                "vertical_wheel": 256
+                "vertical_wheel": -256
               }
             }
           ]
@@ -2199,7 +2199,7 @@
           "to": [
             {
               "mouse_key": {
-                "vertical_wheel": -256
+                "vertical_wheel": 256
               }
             }
           ]


### PR DESCRIPTION
"shift + command + up arrow = mouse wheel up fast" and "shift + command + down arrow = mouse wheel down fast" work in reverse.